### PR TITLE
Remove twitter links

### DIFF
--- a/html/about.html
+++ b/html/about.html
@@ -251,7 +251,6 @@
                 <div class="outline col text-left">
                     <i id="facebook" class="fab fa-facebook"></i>
                     <i id="instagram" class="fab fa-instagram"></i>
-                    <i id="twitter" class="fab fa-twitter"></i>
                     <i id="email" title="Click to copy email" data-toggle="tooltip" class="far fa-envelope"></i>
                 </div>
                 <div id="cursor" class="outline col text-right">

--- a/html/constitution.html
+++ b/html/constitution.html
@@ -152,7 +152,6 @@
                 <div class="outline col text-left">
                     <i id="facebook" class="fab fa-facebook"></i>
                     <i id="instagram" class="fab fa-instagram"></i>
-                    <i id="twitter" class="fab fa-twitter"></i>
                     <i id="email" title="Click to copy email" data-toggle="tooltip" class="far fa-envelope"></i>
                 </div>
                 <div id="cursor" class="outline col text-right">

--- a/html/contact.html
+++ b/html/contact.html
@@ -159,7 +159,6 @@
                 <div class="outline col text-left">
                     <i id="facebook" class="fab fa-facebook"></i>
                     <i id="instagram" class="fab fa-instagram"></i>
-                    <i id="twitter" class="fab fa-twitter"></i>
                     <i id="email" title="Click to copy email" data-toggle="tooltip" class="far fa-envelope"></i>
                 </div>
                 <div id="cursor" class="outline col text-right">

--- a/html/elecnorms.html
+++ b/html/elecnorms.html
@@ -152,7 +152,6 @@
                 <div class="outline col text-left">
                     <i id="facebook" class="fab fa-facebook"></i>
                     <i id="instagram" class="fab fa-instagram"></i>
-                    <i id="twitter" class="fab fa-twitter"></i>
                     <i id="email" title="Click to copy email" data-toggle="tooltip" class="far fa-envelope"></i>
                 </div>
                 <div id="cursor" class="outline col text-right">

--- a/html/events.html
+++ b/html/events.html
@@ -154,7 +154,6 @@
                 <div class="outline col text-left">
                     <i id="facebook" class="fab fa-facebook"></i>
                     <i id="instagram" class="fab fa-instagram"></i>
-                    <i id="twitter" class="fab fa-twitter"></i>
                     <i id="email" title="Click to copy email" data-toggle="tooltip" class="far fa-envelope"></i>
                 </div>
                 <div id="cursor" class="outline col text-right">

--- a/html/resources.html
+++ b/html/resources.html
@@ -178,7 +178,6 @@
                 <div class="outline col text-left">
                     <i id="facebook" class="fab fa-facebook"></i>
                     <i id="instagram" class="fab fa-instagram"></i>
-                    <i id="twitter" class="fab fa-twitter"></i>
                     <i id="email" title="Click to copy email" data-toggle="tooltip" class="far fa-envelope"></i>
                 </div>
                 <div id="cursor" class="outline col text-right">

--- a/index.html
+++ b/index.html
@@ -205,7 +205,6 @@
                 <div class="outline col text-left">
                     <i id="facebook" class="fab fa-facebook"></i>
                     <i id="instagram" class="fab fa-instagram"></i>
-                    <i id="twitter" class="fab fa-twitter"></i>
                     <i id="email" title="Click to copy email" data-toggle="tooltip" class="far fa-envelope"></i>
                 </div>
                 <div id="cursor" class="outline col text-right">


### PR DESCRIPTION
Closes #18. Since the twitter is not being used, VP Communication suggested to remove the button.